### PR TITLE
Data-diff in CI demo

### DIFF
--- a/models/core/dim_orgs.sql
+++ b/models/core/dim_orgs.sql
@@ -1,9 +1,10 @@
 WITH orgs AS (
     SELECT 
         org_id
-        , MIN(event_timestamp) AS created_at
-    FROM {{ ref('signed_in') }}
-    GROUP BY 1
+        , org_name
+        , employee_range
+        , created_at
+    FROM {{ ref('org_created') }}
 )
 
 , user_count AS (


### PR DESCRIPTION
Swapping `sign_up` events  for `org_created` events in model `dim_orgs`

The `dim_orgs` model is built around the first user `sign_up` event, but I noticed we have an `org_created` event that might make more sense to use.

Seems very likely that there could be a big time difference between an org creation and the first user signing in, or an org never having a user sign in.