### PR TITLE
remove elementary

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,0 @@
-packages:
-  - package: elementary-data/elementary
-    version: 0.7.4


### PR DESCRIPTION
Elementary has version requirements that are causing dbt runs in demo PRs to fail:
```
Runtime Error
  Failed to read package: Runtime Error
    This version of dbt is not supported with the 'dbt_utils' package.
      Installed version of dbt: =1.1.4
      Required version of dbt for 'dbt_utils': ['>=1.3.0', '<2.0.0']
    Check for a different version of the 'dbt_utils' package, or run dbt again with --no-version-check
```

Removing the package for now. We can bump up the dbt version if we want to include elementary in this repo.