### PR TITLE
Update dim_orgs: created_at, sub_price, sub_plan (Slim Diff)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "datafold-vscode.dbtProjectDir": "/Users/leoebfolsom/git/demo",
+    "datafold-vscode.dbtProfilesDir": "~/.dbt"
+}

--- a/models/core/dim_orgs.sql
+++ b/models/core/dim_orgs.sql
@@ -2,9 +2,10 @@ WITH orgs AS (
 --prod
     SELECT
         org_id
-        , MIN(event_timestamp) AS created_at
-    FROM {{ ref('signed_in') }}
-    GROUP BY 1
+        , org_name
+        , employee_range
+        , created_at
+    FROM {{ ref('org_created') }}
 
 -- --dev
 --    SELECT
@@ -28,7 +29,7 @@ WITH orgs AS (
         org_id
         , event_timestamp AS sub_created_at
         , plan as sub_plan
-        , price as sub_price
+        , coalesce(price, 0) as sub_price
     FROM {{ ref('subscription_created') }}
 )
 
@@ -38,7 +39,7 @@ SELECT
     , created_at
     , num_users
     , sub_created_at
-    , sub_plan
+    , case when num_users = 1 then 'Individual' else sub_plan end as sub_plan
     , sub_price
 FROM orgs
 LEFT JOIN user_count USING (org_id)

--- a/models/syncs/schema.yml
+++ b/models/syncs/schema.yml
@@ -2,6 +2,10 @@ version: 2
 
 models:
   - name: sales_sync
+      +meta:
+        datafold:
+          datadiff:
+            slim_diff: diff_when_downstream
     columns:
       - name: org_id
         tests:


### PR DESCRIPTION
1. Update logic of `dim_orgs.created_at`
    - The `dim_orgs` model is built around the first user `sign_up` event, but I noticed we have an `org_created` event that might make more sense to use.
    - Seems very likely that there could be a big time difference between an org creation and the first user signing in, or an org never having a user sign in.
    - So, we're swapping `sign_up` events  for `org_created` events in model `dim_orgs`
2. Set `dim_orgs.sub_price` to `0` when the value would be `null`.
3. Recategorize `dim_orgs.sub_plan` to `Individual` when `num_users` is `1`

And a 4th thing, when I noticed an unexpected impact on `sales_sync` when reviewing the Datafold data diffs:

4. Include `Individual` opportunities in the Sales Sync.