### PR TITLE
Refactor dim_orgs and incorporate changes into sales_sync

### DIFF
--- a/models/core/dim_orgs.sql
+++ b/models/core/dim_orgs.sql
@@ -2,9 +2,10 @@ WITH orgs AS (
 --prod
     SELECT
         org_id
-        , MIN(event_timestamp) AS created_at
-    FROM {{ ref('signed_in') }}
-    GROUP BY 1
+        , org_name
+        , employee_range
+        , created_at
+    FROM {{ ref('org_created') }}
 
 -- --dev
 --    SELECT
@@ -28,7 +29,7 @@ WITH orgs AS (
         org_id
         , event_timestamp AS sub_created_at
         , plan as sub_plan
-        , price as sub_price
+        , coalesce(price, 0) as sub_price
     FROM {{ ref('subscription_created') }}
 )
 
@@ -38,7 +39,7 @@ SELECT
     , created_at
     , num_users
     , sub_created_at
-    , sub_plan
+    , case when num_users = 1 then 'Individual' else sub_plan end as sub_plan
     , sub_price
 FROM orgs
 LEFT JOIN user_count USING (org_id)

--- a/models/core/dim_orgs.sql
+++ b/models/core/dim_orgs.sql
@@ -39,7 +39,7 @@ SELECT
     , case when num_users > 2 then 2 else num_users end as num_users
     , sub_created_at
     , case when num_users = 1 then 'Individual' else sub_plan end as sub_plan
-    , case when sub_price = 99 then 100 else sub_price end as sub_orice
+    , case when sub_price = 99 then 100 else sub_price end as sub_price
 FROM orgs
 LEFT JOIN user_count USING (org_id)
 LEFT JOIN subscriptions USING (org_id)

--- a/models/core/dim_orgs.sql
+++ b/models/core/dim_orgs.sql
@@ -36,7 +36,7 @@ WITH orgs AS (
 SELECT
     org_id
     , created_at
-    , num_users
+    , case when num_users > 2 then 2 else num_users end as num_users
     , sub_created_at
     , case when num_users = 1 then 'Individual' else sub_plan end as sub_plan
     , sub_price

--- a/models/core/dim_orgs.sql
+++ b/models/core/dim_orgs.sql
@@ -39,7 +39,7 @@ SELECT
     , case when num_users > 2 then 2 else num_users end as num_users
     , sub_created_at
     , case when num_users = 1 then 'Individual' else sub_plan end as sub_plan
-    , sub_price
+    , case when sub_price = 99 then 100 else sub_price end as sub_orice
 FROM orgs
 LEFT JOIN user_count USING (org_id)
 LEFT JOIN subscriptions USING (org_id)

--- a/models/core/dim_orgs.sql
+++ b/models/core/dim_orgs.sql
@@ -2,10 +2,9 @@ WITH orgs AS (
 --prod
     SELECT
         org_id
-        , org_name
-        , employee_range
-        , created_at
-    FROM {{ ref('org_created') }}
+        , MIN(event_timestamp) AS created_at
+    FROM {{ ref('signed_in') }}
+    GROUP BY 1
 
 -- --dev
 --    SELECT

--- a/models/core/dim_users.sql
+++ b/models/core/dim_users.sql
@@ -7,3 +7,4 @@ WITH users AS (
 SELECT
     user_id
 FROM users
+WHERE 1 = 1

--- a/models/syncs/sales_sync.sql
+++ b/models/syncs/sales_sync.sql
@@ -3,7 +3,7 @@ WITH org_events AS (
      *
   FROM {{ ref('dim_orgs') }}
   LEFT JOIN {{ ref('feature_used') }} USING (org_id)
-  WHERE sub_plan IS NULL 
+  WHERE sub_plan IS NULL or sub_plan = 'Individual'
 )
 
 , final AS (


### PR DESCRIPTION
1. Update logic of `dim_orgs.created_at`
    - The `dim_orgs` model is built around the first user `sign_up` event, but I noticed we have an `org_created` event that might make more sense to use.
    - Seems very likely that there could be a big time difference between an org creation and the first user signing in, or an org never having a user sign in.
    - So, we're swapping `sign_up` events  for `org_created` events in model `dim_orgs`
2. Set `dim_orgs.sub_price` to `0` when the value would be `null`.
3. Recategorize `dim_orgs.sub_plan` to `Individual` when `num_users` is `1`
4. Include `Individual` opportunities in the Sales Sync.
5. Trivial change to `num_users`.