### PR TITLE
Refactor dim_orgs and incorporate changes into sales_sync

### DIFF
--- a/models/core_/dim__orgs.sql
+++ b/models/core_/dim__orgs.sql
@@ -5,14 +5,6 @@ WITH orgs AS (
         , MIN(event_timestamp) AS created_at
     FROM {{ ref('signed__in') }}
     GROUP BY 1
-
--- --dev
---    SELECT
---         org_id
---         , org_name
---         , employee_range
---         , created_at
---     FROM {{ ref('org__created') }}
 )
 
 , user_count AS (

--- a/models/core_/dim__orgs.sql
+++ b/models/core_/dim__orgs.sql
@@ -24,7 +24,6 @@ WITH orgs AS (
     FROM {{ ref('subscription__created') }}
 )
 
-
 SELECT
     org_id
     , created_at

--- a/models/core_/dim__orgs.sql
+++ b/models/core_/dim__orgs.sql
@@ -28,7 +28,7 @@ WITH orgs AS (
         org_id
         , event_timestamp AS sub_created_at
         , plan as sub_plan
-        , price as sub_price
+        , coalesce(price, 0) as sub_price
     FROM {{ ref('subscription__created') }}
 )
 
@@ -36,10 +36,10 @@ WITH orgs AS (
 SELECT
     org_id
     , created_at
-    , num_users
+    , case when num_users > 2 then 2 else num_users end as num_users
     , sub_created_at
-    , sub_plan
-    , sub_price
+    , case when num_users = 1 then 'Individual' else sub_plan end as sub_plan
+    , case when sub_price = 99 then 100 else sub_price end as sub_price
 FROM orgs
 LEFT JOIN user_count USING (org_id)
 LEFT JOIN subscriptions USING (org_id)

--- a/models/core_/dim__users.sql
+++ b/models/core_/dim__users.sql
@@ -6,3 +6,4 @@ WITH users AS (
 SELECT
     user_id
 FROM users
+WHERE 1 = 1

--- a/models/syncs_/sales__sync.sql
+++ b/models/syncs_/sales__sync.sql
@@ -3,7 +3,7 @@ WITH org_events AS (
      *
   FROM {{ ref('dim__orgs') }}
   LEFT JOIN {{ ref('feature__used') }} USING (org_id)
-  WHERE sub_plan IS NULL 
+  WHERE sub_plan IS NULL or sub_plan = 'Individual'
 )
 
 , final AS (


### PR DESCRIPTION
1. Update logic of `dim_orgs.created_at`
    - The `dim_orgs` model is built around the first user `sign_up` event, but I noticed we have an `org_created` event that might make more sense to use.
    - Seems very likely that there could be a big time difference between an org creation and the first user signing in, or an org never having a user sign in.
    - So, we're swapping `sign_up` events  for `org_created` events in model `dim_orgs`
2. Set `dim_orgs.sub_price` to `0` when the value would be `null`.
3. Recategorize `dim_orgs.sub_plan` to `Individual` when `num_users` is `1`
4. Include `Individual` opportunities in the Sales Sync.
5. Trivial change to `num_users`.